### PR TITLE
Move urls

### DIFF
--- a/src/main/java/com/tp/tanks/WebSocketConfig.java
+++ b/src/main/java/com/tp/tanks/WebSocketConfig.java
@@ -20,7 +20,7 @@ public class WebSocketConfig implements WebSocketConfigurer {
 
     @Override
     public void registerWebSocketHandlers(@NotNull WebSocketHandlerRegistry registry) {
-        registry.addHandler(webSocketHandler, "/game")
+        registry.addHandler(webSocketHandler, "/api/game")
                 .addInterceptors(new HttpSessionHandshakeInterceptor())
                 .setAllowedOrigins("*");
     }

--- a/src/main/java/com/tp/tanks/controller/UserController.java
+++ b/src/main/java/com/tp/tanks/controller/UserController.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 @RestController
+@RequestMapping(value = "/api")
 public class UserController {
 
     private final UserService userService;

--- a/src/test/java/com/tp/tanks/controller/UserControllerTest.java
+++ b/src/test/java/com/tp/tanks/controller/UserControllerTest.java
@@ -45,11 +45,11 @@ public class UserControllerTest {
     }
 
     private ResponseEntity<User> signUp(User user) {
-        return restTemplate.postForEntity("/signUp", generateMap(user), User.class);
+        return restTemplate.postForEntity("/api/signUp", generateMap(user), User.class);
     }
 
     private ResponseEntity<User> signIn(User user) {
-        return restTemplate.postForEntity("/signIn", generateMap(user), User.class);
+        return restTemplate.postForEntity("/api/signIn", generateMap(user), User.class);
     }
 
     private HttpEntity getEntity(List<String> cookie) {
@@ -60,11 +60,11 @@ public class UserControllerTest {
     }
 
     private ResponseEntity<User> logout(List<String> cookie) {
-        return restTemplate.exchange("/logout", HttpMethod.GET, getEntity(cookie), User.class);
+        return restTemplate.exchange("/api/logout", HttpMethod.GET, getEntity(cookie), User.class);
     }
 
     private ResponseEntity<User> getProfile(List<String> cookie) {
-        return restTemplate.exchange("/profile", HttpMethod.GET, getEntity(cookie), User.class);
+        return restTemplate.exchange("/api/profile", HttpMethod.GET, getEntity(cookie), User.class);
     }
 
     @Test


### PR DESCRIPTION
add **"/api"** prefix for all urls, because it became necessary to deploy the front on the server with a backend, and it became necessary to give the index.html to the root **location**,